### PR TITLE
Fix license in `composer.json`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         "private message"
     ],
     "type": "flarum-extension",
-    "license": "MIT",
+    "license": "GPL-3.0",
     "authors": [
         {
           "name": "Charlie Kern",


### PR DESCRIPTION
License specified in `LICENSE.txt` in GPL-3.0, `composer.json` should have the same for consistency.